### PR TITLE
Revert "RawGit is shutting down, replace it with jsDelivr"

### DIFF
--- a/bin/dind_scripts/install_kubernetes.sh
+++ b/bin/dind_scripts/install_kubernetes.sh
@@ -17,7 +17,7 @@ fi
 
 if [ ! -f ~/dind-cluster-v1.9.sh ]; then
     cd ~
-    wget https://cdn.jsdelivr.net/gh/Mirantis/kubeadm-dind-cluster/fixed/dind-cluster-v1.9.sh
+    wget https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.9.sh
     chmod +x dind-cluster-v1.9.sh
 else
     echo "DIND Kubernetes script already exists. Nothing to do."

--- a/bin/dind_scripts/launch_kubernetes.sh
+++ b/bin/dind_scripts/launch_kubernetes.sh
@@ -2,7 +2,7 @@
 sudo apt install -y jq
 cd ~
 
-wget https://cdn.jsdelivr.net/gh/kubernetes-sigs/kubeadm-dind-cluster/fixed/dind-cluster-v1.9.sh
+wget https://cdn.rawgit.com/kubernetes-sigs/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.9.sh
 chmod +x dind-cluster-v1.9.sh
 
 sudo ./dind-cluster-v1.9.sh clean


### PR DESCRIPTION
Reverts AISphere/ffdl-trainer#7

https://cdn.jsdelivr.net/gh/Mirantis/kubeadm-dind-cluster/fixed/dind-cluster-v1.9.sh doesn't exist.